### PR TITLE
fixed syntax_trees_dir.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ python setup.py install
 $kenja.historage.convert <your_repository_path> <path_of_working_directory> <path_of_syntax_tree_directory>
 ```
 
-The direcotry ``base_repo`` is a historage converted by kenja.
-
 ## Detect extract method from your historage
 ```
 $kenja.detection.extract_method all <historage_path>

--- a/kenja/convert.py
+++ b/kenja/convert.py
@@ -17,8 +17,8 @@ class CommandParser:
 
     def add_main_argument(self):
         self.parser.add_argument('org_git_dir', help='path of original git repository')
-        self.parser.add_argument('working_dir', help='path of working directory')
-        self.parser.add_argument('syntax_trees_dir', help='path of syntax treses dir')
+        self.parser.add_argument('historage_dir', help='path of historage directory')
+        self.parser.add_argument('syntax_trees_dir', help='path of syntax trees dir')
 
     def add_option_argument(self):
         pass
@@ -46,7 +46,7 @@ class ConvertCommandParser(CommandParser):
     def set_function(self, args):
         print args
 
-        hc = HistorageConverter(args.org_git_dir, args.working_dir)
+        hc = HistorageConverter(args.org_git_dir, args.historage_dir,args.syntax_trees_dir)
 
         if args.parser_processes:
             hc.parser_processes = args.parser_processes
@@ -61,7 +61,7 @@ class ConvertCommandParser(CommandParser):
 
 class ParseCommandParser(CommandParser):
     def set_function(self, args):
-        hc = HistorageConverter(args.org_git_dir, args.working_dir)
+        hc = HistorageConverter(args.org_git_dir, args.working_dir,args.syntax_trees_dir)
         hc.parse_all_java_files()
         pass
 
@@ -77,9 +77,9 @@ class ConstructCommandParser(CommandParser):
             help='create a bare repository for historage'
         )
 
-    def set_function(self, args):
-        hc = HistorageConverter(args.org_git_dir, args.working_dir)
-
+    def set_function(self, args):       
+        hc = HistorageConverter(args.org_git_dir, args.historage_dir,args.syntax_trees_dir)
+        
         if args.syntax_trees_dir:
             hc.syntax_trees_dir = args.syntax_trees_dir
 

--- a/kenja/converter.py
+++ b/kenja/converter.py
@@ -11,16 +11,27 @@ from kenja.committer import SyntaxTreesCommitter
 class HistorageConverter:
     parser_jar_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'lib', 'java-parser.jar')
 
-    def __init__(self, org_git_repo_dir, working_dir):
+    def __init__(self, org_git_repo_dir, historage_dir,syntax_trees_dir):
         if org_git_repo_dir:
             self.org_repo = Repo(org_git_repo_dir)
 
-        if not(os.path.isdir(working_dir)):
-            raise Exception('%s is not a directory' % (working_dir))
+        if os.path.isdir(historage_dir):
+            if os.listdir(historage_dir):
+                raise Exception('%s is not a empty directory' % (historage_dir))
+        else:
+            if os.mkdir(historage_dir):
+                raise Exception('%s has not a parent directory' % (historage_dir))
 
-        self.working_dir = working_dir
+        self.historage_dir = historage_dir
 
-        self.syntax_trees_dir = os.path.join(self.working_dir, 'syntax_trees')
+        if os.path.isdir(syntax_trees_dir):
+            if os.listdir(syntax_trees_dir):
+                raise Exception('%s is not a empty directory' % (syntax_trees_dir))
+        else:
+            if os.mkdir(syntax_trees_dir):
+                raise Exception('%s has not a parent directory' % (syntax_trees_dir))
+
+        self.syntax_trees_dir = syntax_trees_dir
 
         self.num_commits = 0
 
@@ -53,8 +64,7 @@ class HistorageConverter:
         parser_executor.join()
 
     def prepare_base_repo(self):
-        base_repo_dir = os.path.join(self.working_dir, 'base_repo')
-        base_repo = Repo.init(base_repo_dir, bare=self.is_bare_repo)
+        base_repo = Repo.init(self.historage_dir)
         return base_repo
 
     def convert(self):


### PR DESCRIPTION
Fix
1.Changed working_dir to historage_dir.
2.Deleted the function which making "base_repo".
3.Fixed README.md.
4.Fixed directory of making syntax trees.

This pull request will resolve #19
