### PR TITLE
improve performance of java parser execution

### DIFF
--- a/kenja/converter.py
+++ b/kenja/converter.py
@@ -47,7 +47,7 @@ class HistorageConverter:
 
     def parse_all_target_files(self):
         logger.info('create parser processes...')
-        blob_parser = BlobParser(extension_dict, self.syntax_trees_dir)
+        blob_parser = BlobParser(extension_dict, self.syntax_trees_dir, self.org_repo.git_dir)
         parsed_blob = set()
         for commit in get_reversed_topological_ordered_commits(self.org_repo, self.org_repo.refs):
             self.num_commits = self.num_commits + 1

--- a/kenja/parser.py
+++ b/kenja/parser.py
@@ -7,7 +7,9 @@ from subprocess import (
     )
 from multiprocessing import (
     Pool,
-    cpu_count
+    cpu_count,
+    Process,
+    JoinableQueue
     )
 
 
@@ -19,7 +21,7 @@ def execute_parser(cmd, src):
 
 
 class ParserExecutor:
-    def __init__(self, output_dir, processes=None):
+    def __init__(self, output_dir, repo_path, processes=None):
         self.output_dir = output_dir
         self.processes = processes if processes else cpu_count()
         self.pool = Pool(self.processes)
@@ -60,6 +62,65 @@ class JavaParserExecutor(ParserExecutor):
         return cmd
 
 
+class JavaConsumer(Process):
+    parser_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'lib', 'java/java-parser.jar')
+
+    def __init__(self, blobs_queue, repo_path, output_dir):
+        Process.__init__(self)
+        self.blobs_queue = blobs_queue
+        self.output_dir = output_dir
+        self.repo_path = repo_path
+
+    def run(self):
+        parser_process = Popen(self.make_cmd(), stdin=PIPE)
+        while True:
+            blob_hexsha = self.blobs_queue.get()
+            if blob_hexsha is None:
+                break
+            parser_process.stdin.write(blob_hexsha + '\n')
+            self.blobs_queue.task_done()
+
+        parser_process.communicate()
+        self.blobs_queue.task_done()
+
+    def make_cmd(self):
+        cmd = ["java",
+               "-jar",
+               self.parser_path,
+               self.repo_path,
+               self.output_dir
+               ]
+        return cmd
+
+
+class JavaMultipleParserExecutor:
+    def __init__(self, output_dir, repo_path, processes=None):
+        self.target_blobs = JoinableQueue()
+
+        self.num_consumers = processes if processes else cpu_count()
+        self.consumers = [JavaConsumer(self.target_blobs, repo_path, output_dir)
+                          for i in range(self.num_consumers)]
+
+        for consumer in self.consumers:
+            consumer.start()
+
+        self.closed = False
+
+    def parse_blob(self, blob):
+        if self.closed:
+            return
+        self.target_blobs.put(blob.hexsha)
+
+    def join(self):
+        if self.closed:
+            return
+        for i in range(self.num_consumers):
+            self.target_blobs.put(None)
+
+        self.target_blobs.join()
+        self.closed = True
+
+
 class PythonParserExecutor(ParserExecutor):
     def parse_blob(self, blob):
         src = blob.data_stream.read()
@@ -84,17 +145,17 @@ class CSharpParserExecutor(ParserExecutor):
         return cmd
 
 
-blob_parsers = {'java': JavaParserExecutor, 'python': PythonParserExecutor, 'csharp': CSharpParserExecutor}
+blob_parsers = {'java': JavaMultipleParserExecutor, 'python': PythonParserExecutor, 'csharp': CSharpParserExecutor}
 
 
 class BlobParser:
-    def __init__(self, supported_language, output_dir):
-        self.initialize_parsers(supported_language, output_dir)
+    def __init__(self, supported_language, output_dir, repo_path):
+        self.initialize_parsers(supported_language, output_dir, repo_path)
 
-    def initialize_parsers(self, supported_language, output_dir):
+    def initialize_parsers(self, supported_language, output_dir, repo_path):
         self.parsers = {}
         for language, extensions in supported_language.items():
-            parser = blob_parsers[language](output_dir)
+            parser = blob_parsers[language](output_dir, repo_path)
             for extension in extensions:
                 self.parsers[extension] = parser
 


### PR DESCRIPTION
Current implementation makes a lot of process to parse java files.
I changed behaviour of kenja-java-parser to parse multiple blobs in a java process.

New implementation uses multiprocessing.Queue to sharing set of hexsha that are corresponding to java files.