### PR TITLE
git stores tree mode as '4000'. '04000' is not good.

### DIFF
--- a/kenja/git/util.py
+++ b/kenja/git/util.py
@@ -9,7 +9,7 @@ from StringIO import StringIO
 from collections import deque
 
 blob_mode = '100644'
-tree_mode = '040000'
+tree_mode = '40000'
 
 
 def tree_item_str(mode, file_name, binsha):


### PR DESCRIPTION
I have found this issue on July 2014 but have been afraid fixing.
I finally checked the correctness of this fix.