### PR TITLE
Fix #40

### DIFF
--- a/kenja/committer.py
+++ b/kenja/committer.py
@@ -76,7 +76,7 @@ class SyntaxTreesCommitter:
             tree_contents = self.create_readme(tree_contents)
 
 	if last_commit:
-	    self.create_large_names(tree_contents)
+	    tree_contents = self.create_large_names(tree_contents)
 
         new_commit = self.commit(commit, tree_contents)
         self.old2new[commit.hexsha] = new_commit.hexsha
@@ -118,7 +118,6 @@ class SyntaxTreesCommitter:
 
     def create_large_names(self, tree_contents):
         with NamedTemporaryFile() as f:
-            dir_path = os.path.dirname(os.path.realpath(__file__))
             f.write(large_names_as_string())
             f.flush()
             mode, binsha = write_blob_from_path(self.new_repo.odb, f.name)

--- a/kenja/converter.py
+++ b/kenja/converter.py
@@ -97,7 +97,7 @@ class HistorageConverter:
         num_commits = self.num_commits if self.num_commits != 0 else '???'
         for num, commit in izip(count(), get_reversed_topological_ordered_commits(self.org_repo, self.org_repo.refs)):
             logger.info('[%d/%s] convert %s to: %s' % (num, num_commits, commit.hexsha, historage_repo.git_dir))
-            committer.apply_change(commit)
+            committer.apply_change(commit, (num+1)==num_commits)
         committer.create_heads()
         committer.create_tags()
         if not self.is_bare_repo:

--- a/kenja/converter.py
+++ b/kenja/converter.py
@@ -95,9 +95,12 @@ class HistorageConverter:
         historage_repo = self.prepare_historage_repo()
         committer = SyntaxTreesCommitter(Repo(self.org_repo.git_dir), historage_repo, self.syntax_trees_dir)
         num_commits = self.num_commits if self.num_commits != 0 else '???'
+        for head in self.org_repo.heads:
+	    if head.name == 'master':
+                head_hexsha = head.commit.hexsha
         for num, commit in izip(count(), get_reversed_topological_ordered_commits(self.org_repo, self.org_repo.refs)):
             logger.info('[%d/%s] convert %s to: %s' % (num, num_commits, commit.hexsha, historage_repo.git_dir))
-            committer.apply_change(commit, (num+1)==num_commits)
+            committer.apply_change(commit, head_hexsha == commit.hexsha)
         committer.create_heads()
         committer.create_tags()
         if not self.is_bare_repo:


### PR DESCRIPTION
The idea of this pull request is to replace file names having over 250 characters by an automatically generated name, using fewer characters. The substitutions are recorded in the repository in a file named large-names.csv, in the last commit. That way, an user can recover the original names when processing the converted repository. See the attached file for a repository that can be used to test the implementation.

[test.zip](https://github.com/niyaton/kenja/files/487271/test.zip)
